### PR TITLE
Use clearing, non-decaying samples when exporting to graphite

### DIFF
--- a/report/graphite.go
+++ b/report/graphite.go
@@ -52,52 +52,59 @@ func writeStats(r *Recorder, w io.Writer, trimTs bool) {
 	r.Each(func(name string, i interface{}) {
 		switch metric := i.(type) {
 		case metrics.Counter:
-			fmt.Fprintf(w, trim(r.Format.Counter), r.Prefix, name, metric.Count(), now)
-			metric.Clear()
+			if metric.Count() > 0 {
+				fmt.Fprintf(w, trim(r.Format.Counter), r.Prefix, name, metric.Count(), now)
+				metric.Clear()
+			}
 		case metrics.Gauge:
 			fmt.Fprintf(w, trim(r.Format.Gauge), r.Prefix, name, metric.Value(), now)
 		case metrics.GaugeFloat64:
 			fmt.Fprintf(w, trim(r.Format.GaugeFloat64), r.Prefix, name, metric.Value(), now)
 		case metrics.Histogram:
 			h := metric.Snapshot()
-			h.Clear()
-			ps := h.Percentiles(r.Percentiles)
-			fmt.Fprintf(w, trim(r.Format.HistogramCount), r.Prefix, name, h.Count(), now)
-			fmt.Fprintf(w, trim(r.Format.Min), r.Prefix, name, h.Min(), now)
-			fmt.Fprintf(w, trim(r.Format.Max), r.Prefix, name, h.Max(), now)
-			fmt.Fprintf(w, trim(r.Format.Mean), r.Prefix, name, h.Mean(), now)
-			fmt.Fprintf(w, trim(r.Format.Stddev), r.Prefix, name, h.StdDev(), now)
-			for psIdx, psKey := range r.Percentiles {
-				key := strings.Replace(strconv.FormatFloat(psKey*100.0, 'f', -1, 64), ".", "", 1)
-				fmt.Fprintf(w, trim(r.Format.Percentile), r.Prefix, name, key, ps[psIdx], now)
+			if h.Count() > 0 {
+				metric.Clear()
+				ps := h.Percentiles(r.Percentiles)
+				fmt.Fprintf(w, trim(r.Format.HistogramCount), r.Prefix, name, h.Count(), now)
+				fmt.Fprintf(w, trim(r.Format.Min), r.Prefix, name, h.Min(), now)
+				fmt.Fprintf(w, trim(r.Format.Max), r.Prefix, name, h.Max(), now)
+				fmt.Fprintf(w, trim(r.Format.Mean), r.Prefix, name, h.Mean(), now)
+				fmt.Fprintf(w, trim(r.Format.Stddev), r.Prefix, name, h.StdDev(), now)
+				for psIdx, psKey := range r.Percentiles {
+					key := strings.Replace(strconv.FormatFloat(psKey*100.0, 'f', -1, 64), ".", "", 1)
+					fmt.Fprintf(w, trim(r.Format.Percentile), r.Prefix, name, key, ps[psIdx], now)
+				}
 			}
 		case metrics.Meter:
 			m := metric.Snapshot()
-			fmt.Fprintf(w, trim(r.Format.HistogramCount), r.Prefix, name, m.Count(), now)
-			fmt.Fprintf(w, trim(r.Format.Rate1), r.Prefix, name, m.Rate1(), now)
-			fmt.Fprintf(w, trim(r.Format.Mean), r.Prefix, name, m.RateMean(), now)
+			if m.Count() > 0 {
+				fmt.Fprintf(w, trim(r.Format.HistogramCount), r.Prefix, name, m.Count(), now)
+				fmt.Fprintf(w, trim(r.Format.Rate1), r.Prefix, name, m.Rate1(), now)
+				fmt.Fprintf(w, trim(r.Format.Mean), r.Prefix, name, m.RateMean(), now)
+			}
 		case metrics.Timer:
 			t := metric.Snapshot()
-			switch timer := metric.(type) {
-			case *ClearableTimer:
-				timer.Clear()
-			default:
+			if t.Count() > 0 {
+				switch timer := metric.(type) {
+				case *ClearableTimer:
+					timer.Clear()
+				default:
+				}
+				ps := t.Percentiles(r.Percentiles)
+				fmt.Fprintf(w, trim(r.Format.HistogramCount), r.Prefix, name, t.Count(), now)
+				fmt.Fprintf(w, trim(r.Format.Min), r.Prefix, name, t.Min()/int64(du), now)
+				fmt.Fprintf(w, trim(r.Format.Max), r.Prefix, name, t.Max()/int64(du), now)
+				fmt.Fprintf(w, trim(r.Format.Mean), r.Prefix, name, t.Mean()/du, now)
+				fmt.Fprintf(w, trim(r.Format.Stddev), r.Prefix, name, t.StdDev()/du, now)
+				for psIdx, psKey := range r.Percentiles {
+					key := strings.Replace(strconv.FormatFloat(psKey*100.0, 'f', -1, 64), ".", "", 1)
+					fmt.Fprintf(w, trim(r.Format.Percentile), r.Prefix, name, key, ps[psIdx]/du, now)
+				}
+				fmt.Fprintf(w, trim(r.Format.Rate1), r.Prefix, name, t.Rate1(), now)
+				fmt.Fprintf(w, trim(r.Format.Rate5), r.Prefix, name, t.Rate5(), now)
+				fmt.Fprintf(w, trim(r.Format.Rate15), r.Prefix, name, t.Rate15(), now)
+				fmt.Fprintf(w, trim(r.Format.Mean), r.Prefix, name, t.RateMean(), now)
 			}
-			ps := t.Percentiles(r.Percentiles)
-			fmt.Fprintf(w, trim(r.Format.HistogramCount), r.Prefix, name, t.Count(), now)
-			fmt.Fprintf(w, trim(r.Format.Min), r.Prefix, name, t.Min()/int64(du), now)
-			fmt.Fprintf(w, trim(r.Format.Max), r.Prefix, name, t.Max()/int64(du), now)
-			fmt.Fprintf(w, trim(r.Format.Mean), r.Prefix, name, t.Mean()/du, now)
-			fmt.Fprintf(w, trim(r.Format.Stddev), r.Prefix, name, t.StdDev()/du, now)
-			for psIdx, psKey := range r.Percentiles {
-				key := strings.Replace(strconv.FormatFloat(psKey*100.0, 'f', -1, 64), ".", "", 1)
-				fmt.Fprintf(w, trim(r.Format.Percentile), r.Prefix, name, key, ps[psIdx]/du, now)
-			}
-			fmt.Fprintf(w, trim(r.Format.Rate1), r.Prefix, name, t.Rate1(), now)
-			fmt.Fprintf(w, trim(r.Format.Rate5), r.Prefix, name, t.Rate5(), now)
-			fmt.Fprintf(w, trim(r.Format.Rate15), r.Prefix, name, t.Rate15(), now)
-			fmt.Fprintf(w, trim(r.Format.Mean), r.Prefix, name, t.RateMean(), now)
-
 		default:
 			log.Printf("Cannot export unknown metric type %T for '%s'\n", i, name)
 		}

--- a/report/graphite_test.go
+++ b/report/graphite_test.go
@@ -49,7 +49,7 @@ func NewTestServer(t *testing.T, prefix string) (map[string]float64, net.Listene
 
 	r := NewRecorder()
 	r.Prefix = prefix
-
+	r.isExporting = true
 	c := GraphiteConfig{
 		Addr:          ln.Addr().(*net.TCPAddr),
 		FlushInterval: 10 * time.Millisecond,
@@ -70,22 +70,28 @@ func (m DummyMeter) Snapshot() metrics.Meter { return m }
 
 var _ (metrics.Meter) = (*DummyMeter)(nil)
 
-func TestWrites(t *testing.T) {
+func fillMetrics(r *Recorder) {
+	r.Register("bar", DummyMeter{40, 4.0, metrics.NilMeter{}})
+	r.Time("baz", time.Second*5)
+	r.Time("baz", time.Second*4)
+	r.Time("baz", time.Second*3)
+	r.Time("baz", time.Second*2)
+	r.Time("baz", time.Second*1)
+}
+
+func TestGoMetricsWrites(t *testing.T) {
 	res, l, r, c, wg := NewTestServer(t, "foobar")
 	defer l.Close()
 
 	metrics.GetOrRegisterCounter("foo", r).Inc(2)
 
-	r.Register("bar", DummyMeter{40, 4.0, metrics.NilMeter{}})
-
-	metrics.GetOrRegisterTimer("baz", r).Update(time.Second * 5)
-	metrics.GetOrRegisterTimer("baz", r).Update(time.Second * 4)
-	metrics.GetOrRegisterTimer("baz", r).Update(time.Second * 3)
-	metrics.GetOrRegisterTimer("baz", r).Update(time.Second * 2)
-	metrics.GetOrRegisterTimer("baz", r).Update(time.Second * 1)
+	fillMetrics(r)
 
 	wg.Add(1)
 	r.Format = GoMetricsFormats
+	if testing.Verbose() {
+		t.Log("Sening go-metrics format to graphite..")
+	}
 	sendToGraphite(r, c)
 	wg.Wait()
 
@@ -105,12 +111,6 @@ func TestWrites(t *testing.T) {
 		t.Fatal("bad value:", expected, found)
 	}
 
-	if testing.Verbose() {
-		for i, v := range res {
-			t.Log("res", i, v)
-		}
-	}
-
 	if expected, found := 5000.0, res["foobar.baz.99-percentile"]; !floatEquals(found, expected) {
 		t.Fatal("bad value:", expected, found)
 	}
@@ -118,13 +118,19 @@ func TestWrites(t *testing.T) {
 	if expected, found := 3000.0, res["foobar.baz.50-percentile"]; !floatEquals(found, expected) {
 		t.Fatal("bad value:", expected, found)
 	}
+}
 
-	r.Format = OstrichFormats
+func TestOstrichWrites(t *testing.T) {
+	res, l, r, c, wg := NewTestServer(t, "foobar")
+	defer l.Close()
 
-	for k, _ := range res {
-		delete(res, k)
-	}
+	fillMetrics(r)
+
 	wg.Add(1)
+	r.Format = OstrichFormats
+	if testing.Verbose() {
+		t.Log("Sening ostrich format to graphite..")
+	}
 	sendToGraphite(r, c)
 	wg.Wait()
 
@@ -136,17 +142,30 @@ func TestWrites(t *testing.T) {
 		t.Fatal("bad value:", expected, found)
 	}
 
-	if testing.Verbose() {
-		for i, v := range res {
-			t.Log("res", i, v)
-		}
-	}
-
 	if expected, found := 5000.0, res["foobar.baz.percentiles.p99"]; !floatEquals(found, expected) {
 		t.Fatal("bad value:", expected, found)
 	}
 
 	if expected, found := 3000.0, res["foobar.baz.percentiles.p50"]; !floatEquals(found, expected) {
+		t.Fatal("bad value:", expected, found)
+	}
+
+	for k, _ := range res {
+		delete(res, k)
+	}
+
+	wg.Add(1)
+	if testing.Verbose() {
+		t.Log("Sening recently cleared metrics to graphite...")
+	}
+	sendToGraphite(r, c)
+	wg.Wait()
+
+	if expected, found := 0.0, res["foobar.baz.percentiles.p99"]; !floatEquals(found, expected) {
+		t.Fatal("bad value:", expected, found)
+	}
+
+	if expected, found := 0.0, res["foobar.baz.percentiles.p50"]; !floatEquals(found, expected) {
 		t.Fatal("bad value:", expected, found)
 	}
 }

--- a/report/report.go
+++ b/report/report.go
@@ -130,7 +130,7 @@ func (r *Recorder) ReportToServer(graphiteServer, graphitePrefix string) *Record
 
 	cfg := &GraphiteConfig{
 		Addr:          addr,
-		FlushInterval: 30 * time.Second,
+		FlushInterval: 1 * time.Minute,
 	}
 	r.isExporting = true
 

--- a/report/report.go
+++ b/report/report.go
@@ -30,6 +30,7 @@ func Flag() *string {
 
 type Recorder struct {
 	metrics.Registry
+	isExporting  bool
 	Format       ExportFormatStrings
 	DurationUnit time.Duration // Time conversion unit for durations
 	Prefix       string        // Prefix to be prepended to metric names
@@ -39,6 +40,7 @@ type Recorder struct {
 func NewRecorder() *Recorder {
 	return &Recorder{
 		metrics.NewRegistry(),
+		false,
 		OstrichFormats,
 		time.Millisecond,
 		"",
@@ -50,8 +52,27 @@ func (r *Recorder) GetGuage(name string) Guage {
 	return metrics.GetOrRegisterGauge(name, r)
 }
 
+type ClearableTimer struct {
+	metrics.Timer
+	h metrics.Histogram
+}
+
+func (c *ClearableTimer) Clear() {
+	c.h.Clear()
+}
+
+func (r *Recorder) makeTimer() metrics.Timer {
+	if r.isExporting {
+		h := metrics.NewHistogram(metrics.NewUniformSample(1000 * 30))
+		t := metrics.NewCustomTimer(h, metrics.NewMeter())
+		return &ClearableTimer{t, h}
+	} else {
+		return metrics.NewTimer()
+	}
+}
+
 func (r *Recorder) GetTimer(name string) Timer {
-	return metrics.GetOrRegisterTimer(name, r)
+	return r.GetOrRegister(name, r.makeTimer).(Timer)
 }
 
 func (r *Recorder) GetMeter(name string) Meter {
@@ -111,6 +132,8 @@ func (r *Recorder) ReportToServer(graphiteServer, graphitePrefix string) *Record
 		Addr:          addr,
 		FlushInterval: 30 * time.Second,
 	}
+	r.isExporting = true
+
 	go exporter(r, cfg)
 	return r
 }


### PR DESCRIPTION
Only export >0 metrics.
Clear all metrics that can be cleared (e.g. everything but meters and gauges) on export.
When exporting wrap timers so that the underlying histogram is reachable for clearing.
