### PR TITLE
don't clear when exporting to http

### DIFF
--- a/report/formats.go
+++ b/report/formats.go
@@ -16,34 +16,34 @@ type ExportFormatStrings struct {
 }
 
 var GoMetricsFormats = ExportFormatStrings{
-	Counter:        "%s.%s.count %d %d\n",
-	HistogramCount: "%s.%s.count %d %d\n",
-	Gauge:          "%s.%s.value %d %d\n",
-	GaugeFloat64:   "%s.%s.value %f %d\n",
-	Min:            "%s.%s.min %d %d\n",
-	Max:            "%s.%s.max %d %d\n",
-	Mean:           "%s.%s.mean %.2f %d\n",
-	Stddev:         "%s.%s.std-dev %.2f %d\n",
-	Percentile:     "%s.%s.%s-percentile %.2f %d\n",
-	Rate1:          "%s.%s.one-minute %.2f %d\n",
-	Rate5:          "%s.%s.five-minute %.2f %d\n",
-	Rate15:         "%s.%s.fifteen-minute %.2f %d\n",
+	Counter:        "%s.%s.count %d %s\n",
+	HistogramCount: "%s.%s.count %d %s\n",
+	Gauge:          "%s.%s.value %d %s\n",
+	GaugeFloat64:   "%s.%s.value %f %s\n",
+	Min:            "%s.%s.min %d %s\n",
+	Max:            "%s.%s.max %d %s\n",
+	Mean:           "%s.%s.mean %.2f %s\n",
+	Stddev:         "%s.%s.std-dev %.2f %s\n",
+	Percentile:     "%s.%s.%s-percentile %.2f %s\n",
+	Rate1:          "%s.%s.one-minute %.2f %s\n",
+	Rate5:          "%s.%s.five-minute %.2f %s\n",
+	Rate15:         "%s.%s.fifteen-minute %.2f %s\n",
 }
 
 // An alternate export format that formats percentile paths more like twitter's ostrich.
 var OstrichFormats = ExportFormatStrings{
-	Counter:        "%s.%s.count %d %d\n",
-	HistogramCount: "%s.%s.count %d %d\n",
-	Gauge:          "%s.%s.value %d %d\n",
-	GaugeFloat64:   "%s.%s.value %f %d\n",
-	Min:            "%s.%s.min %d %d\n",
-	Max:            "%s.%s.max %d %d\n",
-	Mean:           "%s.%s.mean %.2f %d\n",
-	Stddev:         "%s.%s.std-dev %.2f %d\n",
-	Percentile:     "%s.%s.percentiles.p%s %.2f %d\n",
-	Rate1:          "%s.%s.one-minute %.2f %d\n",
-	Rate5:          "%s.%s.five-minute %.2f %d\n",
-	Rate15:         "%s.%s.fifteen-minute %.2f %d\n",
+	Counter:        "%s.%s.count %d %s\n",
+	HistogramCount: "%s.%s.count %d %s\n",
+	Gauge:          "%s.%s.value %d %s\n",
+	GaugeFloat64:   "%s.%s.value %f %s\n",
+	Min:            "%s.%s.min %d %s\n",
+	Max:            "%s.%s.max %d %s\n",
+	Mean:           "%s.%s.mean %.2f %s\n",
+	Stddev:         "%s.%s.std-dev %.2f %s\n",
+	Percentile:     "%s.%s.percentiles.p%s %.2f %s\n",
+	Rate1:          "%s.%s.one-minute %.2f %s\n",
+	Rate5:          "%s.%s.five-minute %.2f %s\n",
+	Rate15:         "%s.%s.fifteen-minute %.2f %s\n",
 }
 
 var ExportFormats = GoMetricsFormats

--- a/report/graphite.go
+++ b/report/graphite.go
@@ -40,70 +40,74 @@ func sendToGraphite(r *Recorder, c *GraphiteConfig) error {
 	return nil
 }
 
-func writeStats(r *Recorder, w io.Writer, trimTs bool) {
-	trim := func(s string) string {
-		if trimTs {
-			return s[:len(s)-4] + "\n"
-		}
-		return s
+func writeStats(r *Recorder, w io.Writer, forHttp bool) {
+	now := ""
+	if !forHttp {
+		now = fmt.Sprintf("%d", time.Now().Unix())
 	}
-	now := time.Now().Unix()
+
 	du := float64(r.DurationUnit)
 	r.Each(func(name string, i interface{}) {
 		switch metric := i.(type) {
 		case metrics.Counter:
 			if metric.Count() > 0 {
-				fmt.Fprintf(w, trim(r.Format.Counter), r.Prefix, name, metric.Count(), now)
-				metric.Clear()
+				fmt.Fprintf(w, r.Format.Counter, r.Prefix, name, metric.Count(), now)
+				if !forHttp {
+					metric.Clear()
+				}
 			}
 		case metrics.Gauge:
-			fmt.Fprintf(w, trim(r.Format.Gauge), r.Prefix, name, metric.Value(), now)
+			fmt.Fprintf(w, r.Format.Gauge, r.Prefix, name, metric.Value(), now)
 		case metrics.GaugeFloat64:
-			fmt.Fprintf(w, trim(r.Format.GaugeFloat64), r.Prefix, name, metric.Value(), now)
+			fmt.Fprintf(w, r.Format.GaugeFloat64, r.Prefix, name, metric.Value(), now)
 		case metrics.Histogram:
 			h := metric.Snapshot()
 			if h.Count() > 0 {
-				metric.Clear()
+				if !forHttp {
+					metric.Clear()
+				}
 				ps := h.Percentiles(r.Percentiles)
-				fmt.Fprintf(w, trim(r.Format.HistogramCount), r.Prefix, name, h.Count(), now)
-				fmt.Fprintf(w, trim(r.Format.Min), r.Prefix, name, h.Min(), now)
-				fmt.Fprintf(w, trim(r.Format.Max), r.Prefix, name, h.Max(), now)
-				fmt.Fprintf(w, trim(r.Format.Mean), r.Prefix, name, h.Mean(), now)
-				fmt.Fprintf(w, trim(r.Format.Stddev), r.Prefix, name, h.StdDev(), now)
+				fmt.Fprintf(w, r.Format.HistogramCount, r.Prefix, name, h.Count(), now)
+				fmt.Fprintf(w, r.Format.Min, r.Prefix, name, h.Min(), now)
+				fmt.Fprintf(w, r.Format.Max, r.Prefix, name, h.Max(), now)
+				fmt.Fprintf(w, r.Format.Mean, r.Prefix, name, h.Mean(), now)
+				fmt.Fprintf(w, r.Format.Stddev, r.Prefix, name, h.StdDev(), now)
 				for psIdx, psKey := range r.Percentiles {
 					key := strings.Replace(strconv.FormatFloat(psKey*100.0, 'f', -1, 64), ".", "", 1)
-					fmt.Fprintf(w, trim(r.Format.Percentile), r.Prefix, name, key, ps[psIdx], now)
+					fmt.Fprintf(w, r.Format.Percentile, r.Prefix, name, key, ps[psIdx], now)
 				}
 			}
 		case metrics.Meter:
 			m := metric.Snapshot()
 			if m.Count() > 0 {
-				fmt.Fprintf(w, trim(r.Format.HistogramCount), r.Prefix, name, m.Count(), now)
-				fmt.Fprintf(w, trim(r.Format.Rate1), r.Prefix, name, m.Rate1(), now)
-				fmt.Fprintf(w, trim(r.Format.Mean), r.Prefix, name, m.RateMean(), now)
+				fmt.Fprintf(w, r.Format.HistogramCount, r.Prefix, name, m.Count(), now)
+				fmt.Fprintf(w, r.Format.Rate1, r.Prefix, name, m.Rate1(), now)
+				fmt.Fprintf(w, r.Format.Mean, r.Prefix, name, m.RateMean(), now)
 			}
 		case metrics.Timer:
 			t := metric.Snapshot()
 			if t.Count() > 0 {
-				switch timer := metric.(type) {
-				case *ClearableTimer:
-					timer.Clear()
-				default:
+				if !forHttp {
+					switch timer := metric.(type) {
+					case *ClearableTimer:
+						timer.Clear()
+					default:
+					}
 				}
 				ps := t.Percentiles(r.Percentiles)
-				fmt.Fprintf(w, trim(r.Format.HistogramCount), r.Prefix, name, t.Count(), now)
-				fmt.Fprintf(w, trim(r.Format.Min), r.Prefix, name, t.Min()/int64(du), now)
-				fmt.Fprintf(w, trim(r.Format.Max), r.Prefix, name, t.Max()/int64(du), now)
-				fmt.Fprintf(w, trim(r.Format.Mean), r.Prefix, name, t.Mean()/du, now)
-				fmt.Fprintf(w, trim(r.Format.Stddev), r.Prefix, name, t.StdDev()/du, now)
+				fmt.Fprintf(w, r.Format.HistogramCount, r.Prefix, name, t.Count(), now)
+				fmt.Fprintf(w, r.Format.Min, r.Prefix, name, t.Min()/int64(du), now)
+				fmt.Fprintf(w, r.Format.Max, r.Prefix, name, t.Max()/int64(du), now)
+				fmt.Fprintf(w, r.Format.Mean, r.Prefix, name, t.Mean()/du, now)
+				fmt.Fprintf(w, r.Format.Stddev, r.Prefix, name, t.StdDev()/du, now)
 				for psIdx, psKey := range r.Percentiles {
 					key := strings.Replace(strconv.FormatFloat(psKey*100.0, 'f', -1, 64), ".", "", 1)
-					fmt.Fprintf(w, trim(r.Format.Percentile), r.Prefix, name, key, ps[psIdx]/du, now)
+					fmt.Fprintf(w, r.Format.Percentile, r.Prefix, name, key, ps[psIdx]/du, now)
 				}
-				fmt.Fprintf(w, trim(r.Format.Rate1), r.Prefix, name, t.Rate1(), now)
-				fmt.Fprintf(w, trim(r.Format.Rate5), r.Prefix, name, t.Rate5(), now)
-				fmt.Fprintf(w, trim(r.Format.Rate15), r.Prefix, name, t.Rate15(), now)
-				fmt.Fprintf(w, trim(r.Format.Mean), r.Prefix, name, t.RateMean(), now)
+				fmt.Fprintf(w, r.Format.Rate1, r.Prefix, name, t.Rate1(), now)
+				fmt.Fprintf(w, r.Format.Rate5, r.Prefix, name, t.Rate5(), now)
+				fmt.Fprintf(w, r.Format.Rate15, r.Prefix, name, t.Rate15(), now)
+				fmt.Fprintf(w, r.Format.Mean, r.Prefix, name, t.RateMean(), now)
 			}
 		default:
 			log.Printf("Cannot export unknown metric type %T for '%s'\n", i, name)


### PR DESCRIPTION
also trimming the format string for http doesn't work -- it'll complain about the extra arg at runtime.
instead, make `now` a string and blank it for http.
