### PR TITLE
Implement correct aurora shutdown behavior.

### DIFF
--- a/adminz/adminz.go
+++ b/adminz/adminz.go
@@ -244,15 +244,15 @@ func (a *Adminz) ServicezHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *Adminz) quitHandler(w http.ResponseWriter, r *http.Request) {
-	log.Println("quitquitquit called! Pausing service")
+	log.Println("quitquitquit called! Pausing and shutting down service")
 	a.Stop()
 	a.Pause()
+	os.Exit(0)
 }
 
 func (a *Adminz) abortHandler(w http.ResponseWriter, r *http.Request) {
-	log.Println("abortabortabort called! Pausing service")
-	a.Stop()
-	a.Pause()
+	log.Println("abortabortabort called! Shutting down service")
+	os.Exit(0)
 }
 
 func (a *Adminz) gcHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Chatting with @tdyas revealed that the behaviors I added for quitquitquit and
abortabortabort were incorrect. The correct behavior is to shutdown either
gracefully or immediately respectively.