### PR TITLE
Fix README build state buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Foursquare Common Go Libraries
-[![Build Status](https://api.travis-ci.org/foursquare/fsgo.svg)](https://travis- ci.org/foursquare/fsgo) [![Coverage Status](https://coveralls.io/repos/foursquare/fsgo/badge.svg?branch=master&service=github)](https://coveralls.io/github/foursquare/fsgo?branch=master)
+[![Build Status](https://api.travis-ci.org/foursquare/fsgo.svg)](https://travis-ci.org/foursquare/fsgo) [![Coverage Status](https://coveralls.io/repos/foursquare/fsgo/badge.svg?branch=master&service=github)](https://coveralls.io/github/foursquare/fsgo?branch=master)
 
 A collection of reusable libraries and tools for building webservices in Go.
 


### PR DESCRIPTION
Very minor and picky change to remove spacing in travis-ci url to fix build state buttons.

