### PR TITLE
Remove dependence on two internal forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.5
+  - 1.8
 sudo: false
 before_install:
   - mkdir -p $HOME/zk/contrib/fatjar

--- a/net/discovery/service.go
+++ b/net/discovery/service.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/foursquare/curator.go"
+	"github.com/curator-go/curator"
 )
 
 type ServiceDiscovery struct {

--- a/net/discovery/service_test.go
+++ b/net/discovery/service_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/foursquare/curator.go"
+	"github.com/curator-go/curator"
 	"github.com/samuel/go-zookeeper/zk"
 )
 

--- a/net/discovery/tree_cache.go
+++ b/net/discovery/tree_cache.go
@@ -3,7 +3,7 @@ package discovery
 import (
 	"log"
 
-	"github.com/foursquare/curator.go"
+	"github.com/curator-go/curator"
 	"github.com/samuel/go-zookeeper/zk"
 )
 

--- a/report/graphite.go
+++ b/report/graphite.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/foursquare/go-metrics"
+	"github.com/rcrowley/go-metrics"
 )
 
 func (r *Recorder) exporter() {

--- a/report/graphite_test.go
+++ b/report/graphite_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/foursquare/go-metrics"
+	"github.com/rcrowley/go-metrics"
 )
 
 func floatEquals(a, b float64) bool {

--- a/report/report.go
+++ b/report/report.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/foursquare/go-metrics"
+	"github.com/rcrowley/go-metrics"
 )
 
 type Meter interface {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -9,34 +9,34 @@
 			"revisionTime": "2016-06-07T21:24:23Z"
 		},
 		{
-			"checksumSHA1": "YYHn0WltAlAUHKK+2yTlbMAOLzA=",
+			"checksumSHA1": "fgxkKPz4jLzKDSg0Gmx1G0rPOWY=",
 			"path": "github.com/bkaradzic/go-lz4",
-			"revision": "74ddf82598bc4745b965729e9c6a463bedd33049",
-			"revisionTime": "2015-08-21T05:43:00Z"
+			"revision": "7224d8d8f27ef618c0a95f1ae69dbb0488abc33a",
+			"revisionTime": "2016-09-24T22:28:19Z"
 		},
 		{
-			"checksumSHA1": "5rPfda8jFccr3A6heL+JAmi9K9g=",
+			"checksumSHA1": "VhnlgU/Rwo7Q5VVDg9ZHfqQ6xMk=",
+			"path": "github.com/curator-go/curator",
+			"revision": "3844cf4b76fd7c67981c6be153cadd9d054ea03c",
+			"revisionTime": "2016-09-29T17:55:39Z"
+		},
+		{
+			"checksumSHA1": "dvabztWVQX8f6oMLRyv4dLH+TGY=",
 			"path": "github.com/davecgh/go-spew/spew",
-			"revision": "5215b55f46b2b919f50a1df0eaa5886afe4e3b3d",
-			"revisionTime": "2015-11-05T21:09:06Z"
-		},
-		{
-			"checksumSHA1": "FYQSp21PTNmartFGnrhcRNS5k14=",
-			"path": "github.com/foursquare/curator.go",
-			"revision": "1e6880fe4772986b3b21da77214b95f5c91a5a42",
-			"revisionTime": "2015-11-10T21:17:35Z"
-		},
-		{
-			"checksumSHA1": "jelFstKAqZjTsD/7R3a5hgRoF8Y=",
-			"path": "github.com/foursquare/go-metrics",
-			"revision": "304718cefc1a703a3cde605344e48b59a6c186d8",
-			"revisionTime": "2015-09-12T23:06:48Z"
+			"revision": "346938d642f2ec3594ed81d874461961cd0faa76",
+			"revisionTime": "2016-10-29T20:57:26Z"
 		},
 		{
 			"checksumSHA1": "LuFv4/jlrmFNnDb/5SCSEPAM9vU=",
 			"path": "github.com/pmezard/go-difflib/difflib",
 			"revision": "792786c7400a136282c1664665ae0a8db921c6c2",
 			"revisionTime": "2016-01-10T10:55:54Z"
+		},
+		{
+			"checksumSHA1": "KAzbLjI9MzW2tjfcAsK75lVRp6I=",
+			"path": "github.com/rcrowley/go-metrics",
+			"revision": "1f30fe9094a513ce4c700b9a54458bbb0c96996c",
+			"revisionTime": "2016-11-28T21:05:44Z"
 		},
 		{
 			"checksumSHA1": "BQPtSpoc5HVhcMCGA2fMwsfduJ0=",
@@ -51,10 +51,35 @@
 			"revisionTime": "2016-06-07T14:43:47Z"
 		},
 		{
-			"checksumSHA1": "Bn333k9lTndxU3D6n/G5c+GMcYY=",
+			"checksumSHA1": "EO+jcRet/AJ6IY3lBO8l8BLsZWg=",
+			"origin": "github.com/stretchr/testify/vendor/github.com/stretchr/objx",
+			"path": "github.com/stretchr/objx",
+			"revision": "4d4bfba8f1d1027c4fdbe371823030df51419987",
+			"revisionTime": "2017-01-30T11:31:45Z"
+		},
+		{
+			"checksumSHA1": "JXUVA1jky8ZX8w09p2t5KLs97Nc=",
 			"path": "github.com/stretchr/testify/assert",
-			"revision": "8d64eb7173c7753d6419fd4a9caf057398611364",
-			"revisionTime": "2016-05-24T23:42:29Z"
+			"revision": "4d4bfba8f1d1027c4fdbe371823030df51419987",
+			"revisionTime": "2017-01-30T11:31:45Z"
+		},
+		{
+			"checksumSHA1": "WGwMB6WljaeGKzuNCX5M4E8LADE=",
+			"path": "github.com/stretchr/testify/mock",
+			"revision": "4d4bfba8f1d1027c4fdbe371823030df51419987",
+			"revisionTime": "2017-01-30T11:31:45Z"
+		},
+		{
+			"checksumSHA1": "2PpOCNkWnshDrXeCVH2kp3VHhIM=",
+			"path": "github.com/stretchr/testify/require",
+			"revision": "4d4bfba8f1d1027c4fdbe371823030df51419987",
+			"revisionTime": "2017-01-30T11:31:45Z"
+		},
+		{
+			"checksumSHA1": "Dp8TnT65nINpRF/PrxrgmnYLsyA=",
+			"path": "github.com/stretchr/testify/suite",
+			"revision": "4d4bfba8f1d1027c4fdbe371823030df51419987",
+			"revisionTime": "2017-01-30T11:31:45Z"
 		}
 	],
 	"rootPath": "github.com/foursquare/fsgo"


### PR DESCRIPTION
_curator.go_

The original project was abandoned and I've migrated us to the fork
https://github.com/curator-go/curator. That has consumed the code changes david
had originally made to fix some bugs.

_go-metrics_

Upstream has consumed all the changes we made so I'm just moving us back to
upstream at latest.

In order to do the upgrade I had to update a few libraries, but they are all
libraries used to test. The tests continue to pass, so this should be ok.

I also upgraded the lz4 library because it was just a few doc upgrades / readability upgrades.

I also upgraded the travis.yml file to use go1.8 as I had neglected to
previously.