### PR TITLE
Fix objx dep

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -51,10 +51,10 @@
 			"revisionTime": "2016-06-07T14:43:47Z"
 		},
 		{
-			"checksumSHA1": "EO+jcRet/AJ6IY3lBO8l8BLsZWg=",
+			"checksumSHA1": "K0crHygPTP42i1nLKWphSlvOQJw=",
 			"path": "github.com/stretchr/objx",
-			"revision": "4d4bfba8f1d1027c4fdbe371823030df51419987",
-			"revisionTime": "2017-01-30T11:31:45Z"
+			"revision": "1a9d0bb9f541897e62256577b352fdbc1fb4fd94",
+			"revisionTime": "2015-09-28T12:21:52Z"
 		},
 		{
 			"checksumSHA1": "JXUVA1jky8ZX8w09p2t5KLs97Nc=",


### PR DESCRIPTION
I'm not sure what happened here, probably me misunderstanding govendor. Somehow
the dep had been set to the local copy, and the sha was set to HEAD of fsgo.
I've fixed it to be the HEAD of the upstream.